### PR TITLE
feat: add Cloud SQL Proxy samples for MySQL and Postgres

### DIFF
--- a/hello-world/cloud-run/python/mysql/proxy/Dockerfile
+++ b/hello-world/cloud-run/python/mysql/proxy/Dockerfile
@@ -1,0 +1,35 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Use the official lightweight Python image.
+# https://hub.docker.com/_/python
+FROM python:3.11-slim
+
+# Allow statements and log messages to immediately appear in the logs
+ENV PYTHONUNBUFFERED True
+
+# Copy local code to the container image.
+ENV APP_HOME /app
+WORKDIR $APP_HOME
+COPY . ./
+
+# Install production dependencies.
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Run the web service on container startup. Here we use the gunicorn
+# webserver, with one worker process and 8 threads.
+# For environments with multiple CPU cores, increase the number of workers
+# to be equal to the cores available.
+# Timeout is set to 0 to disable the timeouts of the workers to allow Cloud Run to handle instance scaling.
+CMD exec gunicorn --bind :$PORT --workers 1 --threads 8 --timeout 0 main:app

--- a/hello-world/cloud-run/python/mysql/proxy/main.py
+++ b/hello-world/cloud-run/python/mysql/proxy/main.py
@@ -1,0 +1,49 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+import sqlalchemy
+from flask import Flask
+
+app = Flask(__name__)
+
+# lazy initialize global connection pool to improve cold-starts and share
+# connections across requests
+pool = None
+
+
+@app.route("/")
+def hello_world():
+    """Example Hello World route."""
+    global pool
+    if pool is None:
+        pool = pool = sqlalchemy.create_engine(
+            # Equivalent URL:
+            # mysql+pymysql://my-user:my-password@/my-database?unix_socket=/cloudsql/my-project:my-region:my-instance
+            sqlalchemy.engine.url.URL.create(
+                drivername="mysql+pymysql",
+                username="my-user",
+                password="my-password",
+                database="my-database",
+                query={"unix_socket": "/cloudsql/my-project:my-region:my-instance"},
+            )
+        )
+    with pool.connect() as conn:
+        result = conn.execute(sqlalchemy.text("SELECT 'Hello World!'"))
+        return result.scalar()
+
+
+if __name__ == "__main__":
+    app.run(debug=True, host="0.0.0.0", port=int(os.environ.get("PORT", 8080)))

--- a/hello-world/cloud-run/python/mysql/proxy/requirements.txt
+++ b/hello-world/cloud-run/python/mysql/proxy/requirements.txt
@@ -1,0 +1,4 @@
+Flask==3.0.3
+gunicorn==23.0.0
+PyMySQL==1.1.1
+SQLAlchemy==2.0.36

--- a/hello-world/cloud-run/python/postgres/proxy/Dockerfile
+++ b/hello-world/cloud-run/python/postgres/proxy/Dockerfile
@@ -1,0 +1,35 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Use the official lightweight Python image.
+# https://hub.docker.com/_/python
+FROM python:3.11-slim
+
+# Allow statements and log messages to immediately appear in the logs
+ENV PYTHONUNBUFFERED True
+
+# Copy local code to the container image.
+ENV APP_HOME /app
+WORKDIR $APP_HOME
+COPY . ./
+
+# Install production dependencies.
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Run the web service on container startup. Here we use the gunicorn
+# webserver, with one worker process and 8 threads.
+# For environments with multiple CPU cores, increase the number of workers
+# to be equal to the cores available.
+# Timeout is set to 0 to disable the timeouts of the workers to allow Cloud Run to handle instance scaling.
+CMD exec gunicorn --bind :$PORT --workers 1 --threads 8 --timeout 0 main:app

--- a/hello-world/cloud-run/python/postgres/proxy/main.py
+++ b/hello-world/cloud-run/python/postgres/proxy/main.py
@@ -1,0 +1,53 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+import sqlalchemy
+from flask import Flask
+
+app = Flask(__name__)
+
+# lazy initialize global connection pool to improve cold-starts and share
+# connections across requests
+pool = None
+
+
+@app.route("/")
+def hello_world():
+    """Example Hello World route."""
+    global pool
+    if pool is None:
+        pool = pool = sqlalchemy.create_engine(
+            # Equivalent URL:
+            # postgresql+pg8000://<db_user>:<db_pass>@/<db_name>?unix_sock=/cloudsql/my-project:my-region:my-instance/.s.PGSQL.5432
+            # Note: Some drivers require the `unix_sock` query parameter to use a different key.
+            # For example, 'psycopg2' uses the path set to `host` in order to connect successfully.
+            sqlalchemy.engine.url.URL.create(
+                drivername="postgresql+pg8000",
+                username="my-user",
+                password="my-password",
+                database="my-database",
+                query={
+                    "unix_sock": "/cloudsql/my-project:my-region:my-instance/.s.PGSQL.5432"
+                },
+            )
+        )
+    with pool.connect() as conn:
+        result = conn.execute(sqlalchemy.text("SELECT 'Hello World!'"))
+        return result.scalar()
+
+
+if __name__ == "__main__":
+    app.run(debug=True, host="0.0.0.0", port=int(os.environ.get("PORT", 8080)))

--- a/hello-world/cloud-run/python/postgres/proxy/requirements.txt
+++ b/hello-world/cloud-run/python/postgres/proxy/requirements.txt
@@ -1,0 +1,4 @@
+Flask==3.0.3
+gunicorn==23.0.0
+pg8000==1.31.2
+SQLAlchemy==2.0.36


### PR DESCRIPTION
The Cloud SQL Proxy is injected as a sidecar for Cloud Run
deployments deployed with the following flag:

```
--add-cloudsql-instances my-project:my-region:my-instance
```

The Proxy will be listening over a unix socket at the following destination path
`/cloudsql/my-project:my-region:my-instance`