### PR TITLE
feat: add Cloud SQL direct connection samples

### DIFF
--- a/hello-world/cloud-run/python/mysql/direct/Dockerfile
+++ b/hello-world/cloud-run/python/mysql/direct/Dockerfile
@@ -1,0 +1,35 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Use the official lightweight Python image.
+# https://hub.docker.com/_/python
+FROM python:3.12-slim
+
+# Allow statements and log messages to immediately appear in the logs
+ENV PYTHONUNBUFFERED True
+
+# Copy local code to the container image.
+ENV APP_HOME /app
+WORKDIR $APP_HOME
+COPY . ./
+
+# Install production dependencies.
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Run the web service on container startup. Here we use the gunicorn
+# webserver, with one worker process and 8 threads.
+# For environments with multiple CPU cores, increase the number of workers
+# to be equal to the cores available.
+# Timeout is set to 0 to disable the timeouts of the workers to allow Cloud Run to handle instance scaling.
+CMD exec gunicorn --bind :$PORT --workers 1 --threads 8 --timeout 0 main:app

--- a/hello-world/cloud-run/python/mysql/direct/main.py
+++ b/hello-world/cloud-run/python/mysql/direct/main.py
@@ -1,0 +1,50 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+import sqlalchemy
+from flask import Flask
+
+app = Flask(__name__)
+
+# lazy initialize global connection pool to improve cold-starts and share
+# connections across requests
+pool = None
+
+
+@app.route("/")
+def hello_world():
+    """Example Hello World route."""
+    global pool
+    if pool is None:
+        pool = pool = sqlalchemy.create_engine(
+            # Equivalent URL:
+            # mysql+pymysql://my-user:my-password@10.0.0.1:3306/my-database
+            sqlalchemy.engine.url.URL.create(
+                drivername="mysql+pymysql",
+                username="my-user",
+                password="my-password",
+                host="10.0.0.1",  # your Cloud SQL IP address
+                port=3306,
+                database="my-database",
+            )
+        )
+    with pool.connect() as conn:
+        result = conn.execute(sqlalchemy.text("SELECT 'Hello World!'"))
+        return result.scalar()
+
+
+if __name__ == "__main__":
+    app.run(debug=True, host="0.0.0.0", port=int(os.environ.get("PORT", 8080)))

--- a/hello-world/cloud-run/python/mysql/direct/requirements.txt
+++ b/hello-world/cloud-run/python/mysql/direct/requirements.txt
@@ -1,0 +1,4 @@
+Flask==3.0.3
+gunicorn==23.0.0
+PyMySQL==1.1.1
+SQLAlchemy==2.0.36

--- a/hello-world/cloud-run/python/postgres/direct/Dockerfile
+++ b/hello-world/cloud-run/python/postgres/direct/Dockerfile
@@ -1,0 +1,38 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Use the official lightweight Python image.
+# https://hub.docker.com/_/python
+FROM python:3.12-slim
+
+# Allow statements and log messages to immediately appear in the logs
+ENV PYTHONUNBUFFERED True
+
+# Copy local code to the container image.
+ENV APP_HOME /app
+WORKDIR $APP_HOME
+COPY . ./
+
+# Install dependencies to build psycopg from source
+RUN apt-get update && apt-get install -y libpq-dev gcc
+
+# Install production dependencies.
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Run the web service on container startup. Here we use the gunicorn
+# webserver, with one worker process and 8 threads.
+# For environments with multiple CPU cores, increase the number of workers
+# to be equal to the cores available.
+# Timeout is set to 0 to disable the timeouts of the workers to allow Cloud Run to handle instance scaling.
+CMD exec gunicorn --bind :$PORT --workers 1 --threads 8 --timeout 0 main:app

--- a/hello-world/cloud-run/python/postgres/direct/main.py
+++ b/hello-world/cloud-run/python/postgres/direct/main.py
@@ -1,0 +1,51 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+import sqlalchemy
+from flask import Flask
+
+app = Flask(__name__)
+
+# lazy initialize global connection pool to improve cold-starts and share
+# connections across requests
+pool = None
+
+
+@app.route("/")
+def hello_world():
+    """Example Hello World route."""
+    global pool
+    if pool is None:
+        pool = pool = sqlalchemy.create_engine(
+            # Equivalent URL:
+            # postgresql+psycopg://<my-user>:<my-pass>@<host>:<port>/<db-name>
+            sqlalchemy.engine.url.URL.create(
+                drivername="postgresql+psycopg",
+                username="my-user",
+                password="my-password",
+                host="10.0.0.1",  # your Cloud SQL IP address
+                port="5432",
+                database="my-database",
+            ),
+            connect_args={"sslmode": "require"},
+        )
+    with pool.connect() as conn:
+        result = conn.execute(sqlalchemy.text("SELECT 'Hello World!'"))
+        return result.scalar()
+
+
+if __name__ == "__main__":
+    app.run(debug=True, host="0.0.0.0", port=int(os.environ.get("PORT", 8080)))

--- a/hello-world/cloud-run/python/postgres/direct/requirements.txt
+++ b/hello-world/cloud-run/python/postgres/direct/requirements.txt
@@ -1,0 +1,4 @@
+Flask==3.0.3
+gunicorn==23.0.0
+psycopg[binary]==3.2.3
+SQLAlchemy==2.0.36

--- a/hello-world/cloud-run/python/postgres/direct/requirements.txt
+++ b/hello-world/cloud-run/python/postgres/direct/requirements.txt
@@ -1,4 +1,4 @@
 Flask==3.0.3
 gunicorn==23.0.0
-psycopg[binary]==3.2.3
+psycopg==3.2.3
 SQLAlchemy==2.0.36


### PR DESCRIPTION
Add direct TCP connection cloud sql samples to repo.

These connections connect via the Cloud SQL instance's IP address
on the default database port (`5432` for Postgres, `3306` for MySQL)

These samples are optimal for users connecting to a Cloud SQL
private IP address and will provide the least latency.