### PR TITLE
feat: bump Docker base images to Python 3.12

### DIFF
--- a/hello-world/cloud-run/python/mysql/connector/Dockerfile
+++ b/hello-world/cloud-run/python/mysql/connector/Dockerfile
@@ -14,7 +14,7 @@
 
 # Use the official lightweight Python image.
 # https://hub.docker.com/_/python
-FROM python:3.11-slim
+FROM python:3.12-slim
 
 # Allow statements and log messages to immediately appear in the logs
 ENV PYTHONUNBUFFERED True

--- a/hello-world/cloud-run/python/mysql/proxy/Dockerfile
+++ b/hello-world/cloud-run/python/mysql/proxy/Dockerfile
@@ -14,7 +14,7 @@
 
 # Use the official lightweight Python image.
 # https://hub.docker.com/_/python
-FROM python:3.11-slim
+FROM python:3.12-slim
 
 # Allow statements and log messages to immediately appear in the logs
 ENV PYTHONUNBUFFERED True

--- a/hello-world/cloud-run/python/postgres/connector/Dockerfile
+++ b/hello-world/cloud-run/python/postgres/connector/Dockerfile
@@ -14,7 +14,7 @@
 
 # Use the official lightweight Python image.
 # https://hub.docker.com/_/python
-FROM python:3.11-slim
+FROM python:3.12-slim
 
 # Allow statements and log messages to immediately appear in the logs
 ENV PYTHONUNBUFFERED True

--- a/hello-world/cloud-run/python/postgres/proxy/Dockerfile
+++ b/hello-world/cloud-run/python/postgres/proxy/Dockerfile
@@ -14,7 +14,7 @@
 
 # Use the official lightweight Python image.
 # https://hub.docker.com/_/python
-FROM python:3.11-slim
+FROM python:3.12-slim
 
 # Allow statements and log messages to immediately appear in the logs
 ENV PYTHONUNBUFFERED True


### PR DESCRIPTION
Bump `Dockerfile` files to use `python:3.12-slim` as base image over `python:3.11-slim`