### PR TITLE
chore: update typo in `proxy` and `direct` Cloud Run samples

### DIFF
--- a/hello-world/cloud-run/python/mysql/direct/main.py
+++ b/hello-world/cloud-run/python/mysql/direct/main.py
@@ -29,7 +29,7 @@ def hello_world():
     """Example Hello World route."""
     global pool
     if pool is None:
-        pool = pool = sqlalchemy.create_engine(
+        pool = sqlalchemy.create_engine(
             # Equivalent URL:
             # mysql+pymysql://my-user:my-password@10.0.0.1:3306/my-database
             sqlalchemy.engine.url.URL.create(

--- a/hello-world/cloud-run/python/mysql/proxy/main.py
+++ b/hello-world/cloud-run/python/mysql/proxy/main.py
@@ -29,7 +29,7 @@ def hello_world():
     """Example Hello World route."""
     global pool
     if pool is None:
-        pool = pool = sqlalchemy.create_engine(
+        pool = sqlalchemy.create_engine(
             # Equivalent URL:
             # mysql+pymysql://my-user:my-password@/my-database?unix_socket=/cloudsql/my-project:my-region:my-instance
             sqlalchemy.engine.url.URL.create(

--- a/hello-world/cloud-run/python/postgres/direct/main.py
+++ b/hello-world/cloud-run/python/postgres/direct/main.py
@@ -29,7 +29,7 @@ def hello_world():
     """Example Hello World route."""
     global pool
     if pool is None:
-        pool = pool = sqlalchemy.create_engine(
+        pool = sqlalchemy.create_engine(
             # Equivalent URL:
             # postgresql+psycopg://<my-user>:<my-pass>@<host>:<port>/<db-name>
             sqlalchemy.engine.url.URL.create(

--- a/hello-world/cloud-run/python/postgres/proxy/main.py
+++ b/hello-world/cloud-run/python/postgres/proxy/main.py
@@ -29,7 +29,7 @@ def hello_world():
     """Example Hello World route."""
     global pool
     if pool is None:
-        pool = pool = sqlalchemy.create_engine(
+        pool = sqlalchemy.create_engine(
             # Equivalent URL:
             # postgresql+pg8000://<db_user>:<db_pass>@/<db_name>?unix_sock=/cloudsql/my-project:my-region:my-instance/.s.PGSQL.5432
             # Note: Some drivers require the `unix_sock` query parameter to use a different key.


### PR DESCRIPTION
Remove unnecessary double assignment typo.